### PR TITLE
Remove stage dimension from cloudwatch metric and bump version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,5 +130,6 @@ assetmonitor: {
 ## Release History
 
 ### 0.1.0 (23rd December 2013)
+### 0.1.3 (2nd January 2014)
 
 * Initial release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-asset-monitor",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Grunt task to analyse and log simple metrics of static assets to Amazon CloudWatch.",
   "homepage": "https://github.com/guardian/grunt-asset-monitor",
   "author": {

--- a/tasks/lib/cloudwatch.js
+++ b/tasks/lib/cloudwatch.js
@@ -55,10 +55,6 @@ module.exports = {
                     Unit : 'Kilobytes',
                     Dimensions : [
                         {
-                            Name : 'Stage',
-                            Value : 'PROD'
-                        },
-                        {
                             Name : 'Compression',
                             Value : 'None'
                         }
@@ -69,10 +65,6 @@ module.exports = {
                     Value : metricData.compressed,
                     Unit : 'Kilobytes',
                     Dimensions : [
-                        {
-                            Name : 'Stage',
-                            Value : 'PROD'
-                        },
                         {
                             Name : 'Compression',
                             Value : 'GZip'


### PR DESCRIPTION
Removes the unnecessary `stage` dimension we were pushing with each cloudwatch data set.

/cc @rich-nguyen 
